### PR TITLE
Use writable URL when cloning map repos

### DIFF
--- a/bin/clone_all.sh
+++ b/bin/clone_all.sh
@@ -1,16 +1,12 @@
 #!/bin/bash
 
-
- ## note:
- ##  -  it appears that it takes some time for a repo to show up in an orgs repo list
- ##  -  the curl call below is rate limited, not intended for repeated invocations
+## note:
+##  -  it appears that it takes some time for a repo to show up in an orgs repo list
+##  -  the curl call below is rate limited, not intended for repeated invocations
 
 for j in 1 2; do
-  while read gitUrl; do 
-    echo "clone $gitUrl"; 
-    git clone $gitUrl; 
-  done < <(curl --silent "https://api.github.com/orgs/triplea-maps/repos?page=$j&per_page=1000" | grep git_url  | sed 's/.*git:/git:/' | sed 's/",//')
+  while read gitUrl; do
+    echo "clone $gitUrl"
+    git clone $gitUrl
+  done < <(curl --silent "https://api.github.com/orgs/triplea-maps/repos?page=$j&per_page=1000" | grep ssh_url  | sed 's/\s*"ssh_url": "//' | sed 's/",//')
 done
-
-
-


### PR DESCRIPTION
(This PR has been migrated from triplea-maps/map_making_tools_cold_storage#90.  Please see that PR for the complete discussion thread.)

The Git protocol does not support authentication, and thus cannot be used to push changes back to GitHub. I ran into this recently while trying to mass update all triplea-maps repos. After committing the changes, all of my pushes failed because the repos were cloned using `git:` URLs, which are not writable on GitHub. This PR modifies the _clone_all.sh_ script to clone all repos using the SSH protocol, which does permit changes to be pushed back to GitHub (assuming the user has registered their SSH key with GitHub).

I also removed some unnecessary trailing semi-colons and whitespace.